### PR TITLE
Update download URLs after repo renames (rfs->zos_rfs, zinit->zos_zinit)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.23
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23
         id: go

--- a/bins/packages/rfs/rfs.sh
+++ b/bins/packages/rfs/rfs.sh
@@ -2,8 +2,8 @@ RFS_VERSION_V1="1.1.4"
 RFS_VERSION_V2="2.0.6"
 RFS_CHECKSUM_V1="e13b70eae20f1bdf5c205c6252192ef2"
 RFS_CHECKSUM_V2="9e37743dfe94b4577ccf90c573c07638"
-RFS_LINK_V1="https://github.com/threefoldtech/rfs/releases/download/v${RFS_VERSION_V1}/rfs"
-RFS_LINK_V2="https://github.com/threefoldtech/rfs/releases/download/v${RFS_VERSION_V2}/rfs"
+RFS_LINK_V1="https://github.com/threefoldtech/zos_rfs/releases/download/v${RFS_VERSION_V1}/rfs"
+RFS_LINK_V2="https://github.com/threefoldtech/zos_rfs/releases/download/v${RFS_VERSION_V2}/rfs"
 
 download_rfs() {
     download_file ${RFS_LINK_V1} ${RFS_CHECKSUM_V1} rfs-${RFS_VERSION_V1}

--- a/qemu/README.md
+++ b/qemu/README.md
@@ -22,7 +22,7 @@ This will download the latest prebuilt kernel from our server.
 
 In order to use the full power of theses scripts, you'll need in addition:
 
-- A self compiled version of [z-init](https://github.com/threefoldtech/zinit/)
+- A self compiled version of [z-init](https://github.com/threefoldtech/zos_zinit/)
 - All the binaries from this repository compiled
 - A working qemu with ipv6 internet reachability
 

--- a/scripts/debug_image.md
+++ b/scripts/debug_image.md
@@ -49,7 +49,7 @@ NOTE:
 
 - [cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor): hypervisor that booting the machine
 - [virtiofsd](https://gitlab.com/muhamad.azmy/virtiofsd/): used to share a host directory for the rootfs. we are using a forked version
-- [rfs v1](https://github.com/threefoldtech/rfs/tree/v1): mounts the flist file into a directory serving as the lower layer of the overlay file system.
+- [rfs v1](https://github.com/threefoldtech/zos_rfs/tree/v1): mounts the flist file into a directory serving as the lower layer of the overlay file system.
 - `overlayfs`: mounts a read-write layer on the rootfs
 
 ## Script Walkthrough
@@ -101,7 +101,7 @@ NOTE:
 - **rfs**
 
     ```bash
-    wget https://github.com/threefoldtech/rfs/releases/download/v1.1.1/rfs
+    wget https://github.com/threefoldtech/zos_rfs/releases/download/v1.1.1/rfs
     chmod +x ./rfs
 
     sudo ln -s $(realpath ./rfs) /usr/local/bin/rfs1

--- a/scripts/debug_image.sh
+++ b/scripts/debug_image.sh
@@ -106,7 +106,7 @@ check_or_install_deps() {
     fi
 
     if ! command -v rfs1 &>/dev/null; then
-        wget https://github.com/threefoldtech/rfs/releases/download/v1.1.1/rfs
+        wget https://github.com/threefoldtech/zos_rfs/releases/download/v1.1.1/rfs
         chmod +x rfs
         sudo ln -s $(realpath ./rfs) /usr/local/bin/rfs1
     fi


### PR DESCRIPTION
Repoints rfs release-download URLs (`bins/packages/rfs/rfs.sh`, `scripts/debug_image.sh` + doc) and a zinit doc link at the new repo names instead of relying on GitHub's non-permanent rename redirects. Verified rfs versions return 200. No functional change.

Scope: P0 only. Go module deps (zosbase/tfchain/tfgrid-sdk-go) are the separate module-path migration; the zos-config config URL is inherited via the `zosbase` dependency (handled in zos_base).

Part of the repo-rename migration off GitHub redirects.